### PR TITLE
test(firmware): native unit tests for protocol, S-curve, motion planner (S5-20/21/24, V-08)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,24 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+
+  # 第二個任務：ESP32 韌體原生單元測試 (V-08)
+  # 在 Ubuntu 的 GCC 工具鏈上執行 protocol / scurve / motion_planner 的數學驗證，
+  # 不需要實體硬體 (SM-TODO-001 S5-20/21/24)
+  firmware-native-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install PlatformIO
+      run: pip install platformio
+
+    - name: Run firmware native unit tests
+      run: pio test -e native --project-dir firmware/esp32

--- a/firmware/esp32/platformio.ini
+++ b/firmware/esp32/platformio.ini
@@ -2,6 +2,10 @@
 ; LEGO Sorter V2 - ESP32 Firmware
 ; Document: SM-DES-007 Motion Control Design
 
+[platformio]
+; pio run builds only the device firmware; the native env is test-only
+default_envs = esp32dev
+
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
@@ -13,13 +17,16 @@ build_flags =
 lib_deps =
 build_type = release
 
-; Native environment for unit tests (optional - requires g++ on PATH)
-; Uncomment to run: pio test -e native
-; [env:native]
-; platform = native
-; build_flags = -std=c++17
-; build_src_filter =
-;     +<../include/*>
-;     +<../src/protocol.cpp>
-;     +<../src/scurve.cpp>
-; test_build_src = true
+; Native environment for unit tests (requires gcc/g++ on PATH; runs in CI)
+; Run: pio test -e native
+; test/stubs/ provides an Arduino.h shim and a StepperDriver fake so the
+; three pure-logic modules build without the ESP32 Arduino core.
+[env:native]
+platform = native
+build_flags = -std=c++17 -Itest/stubs
+build_src_filter =
+    +<protocol.cpp>
+    +<scurve.cpp>
+    +<motion_planner.cpp>
+    +<../test/stubs/stepper_stub.cpp>
+test_build_src = true

--- a/firmware/esp32/test/stubs/Arduino.h
+++ b/firmware/esp32/test/stubs/Arduino.h
@@ -1,0 +1,46 @@
+/**
+ * @file Arduino.h
+ * @brief Native-build shim standing in for the ESP32 Arduino core.
+ *
+ * Used only by [env:native] (pio test -e native). Provides just enough of
+ * the Arduino surface for protocol.cpp / scurve.cpp / motion_planner.cpp
+ * to compile on a desktop toolchain. Never included in the esp32dev build.
+ */
+
+#ifndef ARDUINO_NATIVE_SHIM_H
+#define ARDUINO_NATIVE_SHIM_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include <ctype.h>
+
+#define HIGH 1
+#define LOW 0
+
+// ESP32-specific attribute: no-op on native
+#define IRAM_ATTR
+
+// Opaque hardware-timer type (only ever used as a pointer in headers)
+typedef struct hw_timer_s hw_timer_t;
+
+inline void delay(unsigned long) {}
+
+inline unsigned long millis() {
+    static unsigned long fakeMillis = 0;
+    return ++fakeMillis;
+}
+
+// Arduino provides min/max; native stdlib does not (as free functions on
+// mixed integer types the firmware uses)
+#ifndef ARDUINO
+template <typename T>
+inline T max(T a, T b) { return (a > b) ? a : b; }
+template <typename T>
+inline T min(T a, T b) { return (a < b) ? a : b; }
+#endif
+
+#endif // ARDUINO_NATIVE_SHIM_H

--- a/firmware/esp32/test/stubs/stepper_stub.cpp
+++ b/firmware/esp32/test/stubs/stepper_stub.cpp
@@ -1,0 +1,91 @@
+/**
+ * @file stepper_stub.cpp
+ * @brief Native fake of StepperDriver for MotionPlanner unit tests.
+ *
+ * Implements the subset of StepperDriver (include/stepper_driver.h) that
+ * motion_planner.cpp links against. Compiled only in [env:native] via
+ * build_src_filter; the real stepper_driver.cpp is excluded there.
+ */
+
+#include "stepper_driver.h"
+#include "stepper_stub.h"
+
+namespace stepper_stub {
+
+int beginCalls = 0;
+int startMoveCalls = 0;
+int stopCalls = 0;
+int resetPositionCalls = 0;
+
+float lastDx = 0.0f;
+float lastDy = 0.0f;
+float lastFeedrate = 0.0f;
+
+bool startMoveResult = true;
+bool movingFlag = false;
+
+void reset() {
+    beginCalls = 0;
+    startMoveCalls = 0;
+    stopCalls = 0;
+    resetPositionCalls = 0;
+    lastDx = 0.0f;
+    lastDy = 0.0f;
+    lastFeedrate = 0.0f;
+    startMoveResult = true;
+    movingFlag = false;
+}
+
+}  // namespace stepper_stub
+
+StepperDriver& StepperDriver::getInstance() {
+    static StepperDriver instance;
+    return instance;
+}
+
+StepperDriver::StepperDriver()
+    : enabled(false)
+    , moving(false)
+    , moveComplete(false)
+    , posX(0.0f)
+    , posY(0.0f)
+    , bresenhamError(0.0f)
+    , bresenhamRatio(0.0f)
+    , dirX(false)
+    , dirY(false)
+    , xIsMajor(false)
+    , timer(nullptr)
+    , timerRunning(false)
+    , stepPinHigh(false)
+    , stepPinMaskX(0)
+    , stepPinMaskY(0) {
+    segment.stepsX = 0;
+    segment.stepsY = 0;
+    segment.totalSteps = 0;
+    segment.currentVelocity = 0.0f;
+    segment.active = false;
+}
+
+void StepperDriver::begin() {
+    stepper_stub::beginCalls++;
+}
+
+bool StepperDriver::startMove(float dx, float dy, float feedrate) {
+    stepper_stub::startMoveCalls++;
+    stepper_stub::lastDx = dx;
+    stepper_stub::lastDy = dy;
+    stepper_stub::lastFeedrate = feedrate;
+    return stepper_stub::startMoveResult;
+}
+
+bool StepperDriver::isMoving() const {
+    return stepper_stub::movingFlag;
+}
+
+void StepperDriver::stop() {
+    stepper_stub::stopCalls++;
+}
+
+void StepperDriver::resetPosition() {
+    stepper_stub::resetPositionCalls++;
+}

--- a/firmware/esp32/test/stubs/stepper_stub.h
+++ b/firmware/esp32/test/stubs/stepper_stub.h
@@ -1,0 +1,33 @@
+/**
+ * @file stepper_stub.h
+ * @brief Test hooks for the native StepperDriver stub.
+ *
+ * stepper_stub.cpp provides a fake implementation of the StepperDriver
+ * class (declared in include/stepper_driver.h) so MotionPlanner can be
+ * unit-tested without ESP32 timer hardware. These hooks let tests inspect
+ * and control the fake.
+ */
+
+#ifndef STEPPER_STUB_H
+#define STEPPER_STUB_H
+
+namespace stepper_stub {
+
+extern int beginCalls;
+extern int startMoveCalls;
+extern int stopCalls;
+extern int resetPositionCalls;
+
+extern float lastDx;
+extern float lastDy;
+extern float lastFeedrate;
+
+extern bool startMoveResult;  // return value for the next startMove()
+extern bool movingFlag;       // what isMoving() reports
+
+// Reset all counters and recorded values to defaults
+void reset();
+
+}  // namespace stepper_stub
+
+#endif // STEPPER_STUB_H

--- a/firmware/esp32/test/test_motion/test_motion.cpp
+++ b/firmware/esp32/test/test_motion/test_motion.cpp
@@ -1,0 +1,205 @@
+/**
+ * @file test_motion.cpp
+ * @brief Native unit tests for MotionPlanner (SM-DES-007 §5, todolist S5-24).
+ *
+ * Uses the StepperDriver fake in test/stubs/stepper_stub.cpp so the XY
+ * Bresenham planning math runs without ESP32 timer hardware.
+ *
+ * Run with: pio test -e native
+ */
+
+#include <unity.h>
+#include <math.h>
+#include "motion_planner.h"
+#include "stepper_stub.h"
+
+static MotionPlanner& planner = MotionPlanner::getInstance();
+
+void setUp() {
+    // Reset planner position first (calls the stub), then zero stub counters
+    planner.setPosition(0.0f, 0.0f);
+    stepper_stub::reset();
+}
+
+void tearDown() {}
+
+// ------------------------------------------------------------- planning
+
+void test_plan_absolute_basic() {
+    PlannedMove m = planner.planAbsolute(100.0f, 50.0f, 3000.0f);
+    TEST_ASSERT_TRUE(m.valid);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, sqrtf(100.0f * 100.0f + 50.0f * 50.0f), m.distance);
+    TEST_ASSERT_EQUAL_INT32(100 * STEPS_PER_MM, m.stepsX);
+    TEST_ASSERT_EQUAL_INT32(50 * STEPS_PER_MM, m.stepsY);
+    TEST_ASSERT_EQUAL_INT32(100 * STEPS_PER_MM, m.totalSteps);
+    TEST_ASSERT_TRUE(m.dirXPositive);
+    TEST_ASSERT_TRUE(m.dirYPositive);
+}
+
+void test_plan_bresenham_x_major() {
+    PlannedMove m = planner.planAbsolute(100.0f, 50.0f, 3000.0f);
+    TEST_ASSERT_TRUE(m.xIsMajor);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.5f, m.bresenhamRatio);
+}
+
+void test_plan_bresenham_y_major() {
+    PlannedMove m = planner.planAbsolute(10.0f, 40.0f, 3000.0f);
+    TEST_ASSERT_TRUE(m.valid);
+    TEST_ASSERT_FALSE(m.xIsMajor);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.25f, m.bresenhamRatio);
+    TEST_ASSERT_EQUAL_INT32(40 * STEPS_PER_MM, m.totalSteps);
+}
+
+void test_plan_bresenham_equal_steps() {
+    // stepsX == stepsY: X wins the major-axis tie, ratio = 1
+    PlannedMove m = planner.planAbsolute(40.0f, 40.0f, 3000.0f);
+    TEST_ASSERT_TRUE(m.xIsMajor);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 1.0f, m.bresenhamRatio);
+}
+
+void test_plan_pure_x_move() {
+    PlannedMove m = planner.planAbsolute(50.0f, 0.0f, 3000.0f);
+    TEST_ASSERT_TRUE(m.valid);
+    TEST_ASSERT_TRUE(m.xIsMajor);
+    TEST_ASSERT_EQUAL_INT32(0, m.stepsY);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, m.bresenhamRatio);
+}
+
+void test_plan_pure_y_move() {
+    PlannedMove m = planner.planAbsolute(0.0f, 50.0f, 3000.0f);
+    TEST_ASSERT_TRUE(m.valid);
+    TEST_ASSERT_FALSE(m.xIsMajor);
+    TEST_ASSERT_EQUAL_INT32(0, m.stepsX);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, m.bresenhamRatio);
+}
+
+void test_plan_relative_directions() {
+    planner.setPosition(10.0f, 10.0f);
+    PlannedMove m = planner.planRelative(-5.0f, 20.0f, 3000.0f);
+    TEST_ASSERT_TRUE(m.valid);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 5.0f, m.endX);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 30.0f, m.endY);
+    TEST_ASSERT_FALSE(m.dirXPositive);
+    TEST_ASSERT_TRUE(m.dirYPositive);
+    TEST_ASSERT_EQUAL_INT32(5 * STEPS_PER_MM, m.stepsX);
+    TEST_ASSERT_EQUAL_INT32(20 * STEPS_PER_MM, m.stepsY);
+}
+
+void test_plan_zero_distance_move() {
+    planner.setPosition(30.0f, 40.0f);
+    PlannedMove m = planner.planAbsolute(30.0f, 40.0f, 3000.0f);
+    TEST_ASSERT_TRUE(m.valid);
+    TEST_ASSERT_EQUAL_INT32(0, m.totalSteps);
+}
+
+void test_plan_scurve_integration() {
+    // feedrate mm/min is converted to mm/s for the S-curve
+    PlannedMove m = planner.planAbsolute(100.0f, 0.0f, 3000.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 3000.0f / 60.0f, m.scurve.vCruise);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 100.0f, m.scurve.distance);
+}
+
+// ------------------------------------------------------------ validation
+
+void test_plan_bounds_max_corner_ok() {
+    PlannedMove m = planner.planAbsolute(X_MAX_MM, Y_MAX_MM, 3000.0f);
+    TEST_ASSERT_TRUE(m.valid);
+}
+
+void test_plan_out_of_bounds_rejected() {
+    TEST_ASSERT_FALSE(planner.planAbsolute(X_MAX_MM + 0.1f, 0.0f, 3000.0f).valid);
+    TEST_ASSERT_FALSE(planner.planAbsolute(0.0f, Y_MAX_MM + 0.1f, 3000.0f).valid);
+    TEST_ASSERT_FALSE(planner.planAbsolute(-0.1f, 0.0f, 3000.0f).valid);
+    TEST_ASSERT_FALSE(planner.planAbsolute(0.0f, -0.1f, 3000.0f).valid);
+}
+
+void test_plan_feedrate_clamped() {
+    float maxFeedrate = V_MAX_MM_S * 60.0f;
+    PlannedMove m1 = planner.planAbsolute(100.0f, 0.0f, 10000.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, maxFeedrate, m1.feedrate);
+    PlannedMove m2 = planner.planAbsolute(100.0f, 0.0f, 0.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, maxFeedrate, m2.feedrate);
+    PlannedMove m3 = planner.planAbsolute(100.0f, 0.0f, -50.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, maxFeedrate, m3.feedrate);
+}
+
+// ------------------------------------------------------------- execution
+
+void test_execute_dispatches_to_stepper() {
+    PlannedMove m = planner.planAbsolute(50.0f, 20.0f, 1500.0f);
+    TEST_ASSERT_TRUE(planner.execute(m));
+    TEST_ASSERT_EQUAL_INT(1, stepper_stub::startMoveCalls);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 50.0f, stepper_stub::lastDx);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 20.0f, stepper_stub::lastDy);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1500.0f, stepper_stub::lastFeedrate);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 50.0f, planner.getX());
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 20.0f, planner.getY());
+}
+
+void test_execute_invalid_move_refused() {
+    PlannedMove m = planner.planAbsolute(X_MAX_MM + 10.0f, 0.0f, 3000.0f);
+    TEST_ASSERT_FALSE(planner.execute(m));
+    TEST_ASSERT_EQUAL_INT(0, stepper_stub::startMoveCalls);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, planner.getX());
+}
+
+void test_execute_zero_step_move_skips_stepper() {
+    planner.setPosition(30.0f, 40.0f);
+    stepper_stub::reset();
+    PlannedMove m = planner.planAbsolute(30.0f, 40.0f, 3000.0f);
+    TEST_ASSERT_TRUE(planner.execute(m));
+    TEST_ASSERT_EQUAL_INT(0, stepper_stub::startMoveCalls);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 30.0f, planner.getX());
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 40.0f, planner.getY());
+}
+
+void test_execute_stepper_failure_keeps_position() {
+    stepper_stub::startMoveResult = false;
+    PlannedMove m = planner.planAbsolute(50.0f, 20.0f, 1500.0f);
+    TEST_ASSERT_FALSE(planner.execute(m));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, planner.getX());
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, planner.getY());
+}
+
+// --------------------------------------------------------- state passthrough
+
+void test_set_position_resets_stepper() {
+    planner.setPosition(5.0f, 7.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 5.0f, planner.getX());
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 7.0f, planner.getY());
+    TEST_ASSERT_EQUAL_INT(1, stepper_stub::resetPositionCalls);
+}
+
+void test_stop_and_is_moving_passthrough() {
+    planner.stop();
+    TEST_ASSERT_EQUAL_INT(1, stepper_stub::stopCalls);
+    stepper_stub::movingFlag = true;
+    TEST_ASSERT_TRUE(planner.isMoving());
+    stepper_stub::movingFlag = false;
+    TEST_ASSERT_FALSE(planner.isMoving());
+}
+
+// -------------------------------------------------------------------- main
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_plan_absolute_basic);
+    RUN_TEST(test_plan_bresenham_x_major);
+    RUN_TEST(test_plan_bresenham_y_major);
+    RUN_TEST(test_plan_bresenham_equal_steps);
+    RUN_TEST(test_plan_pure_x_move);
+    RUN_TEST(test_plan_pure_y_move);
+    RUN_TEST(test_plan_relative_directions);
+    RUN_TEST(test_plan_zero_distance_move);
+    RUN_TEST(test_plan_scurve_integration);
+    RUN_TEST(test_plan_bounds_max_corner_ok);
+    RUN_TEST(test_plan_out_of_bounds_rejected);
+    RUN_TEST(test_plan_feedrate_clamped);
+    RUN_TEST(test_execute_dispatches_to_stepper);
+    RUN_TEST(test_execute_invalid_move_refused);
+    RUN_TEST(test_execute_zero_step_move_skips_stepper);
+    RUN_TEST(test_execute_stepper_failure_keeps_position);
+    RUN_TEST(test_set_position_resets_stepper);
+    RUN_TEST(test_stop_and_is_moving_passthrough);
+    return UNITY_END();
+}

--- a/firmware/esp32/test/test_protocol/test_protocol.cpp
+++ b/firmware/esp32/test/test_protocol/test_protocol.cpp
@@ -1,0 +1,306 @@
+/**
+ * @file test_protocol.cpp
+ * @brief Native unit tests for ProtocolParser (SM-DES-003, todolist S5-20).
+ *
+ * Run with: pio test -e native
+ */
+
+#include <unity.h>
+#include "protocol.h"
+
+static ProtocolParser parser;
+
+void setUp() {
+    parser = ProtocolParser();
+}
+
+void tearDown() {}
+
+// ---------------------------------------------------------------- G1 parsing
+
+void test_g1_full_parameters() {
+    Command cmd = parser.parse("G1 X10.5 Y20.0 F1500");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_EQUAL(CommandType::G1, cmd.type);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 10.5f, cmd.x);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 20.0f, cmd.y);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1500.0f, cmd.f);
+}
+
+void test_g1_compact_no_spaces() {
+    Command cmd = parser.parse("G1X10Y20F1500");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 10.0f, cmd.x);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 20.0f, cmd.y);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1500.0f, cmd.f);
+}
+
+void test_g1_lowercase() {
+    Command cmd = parser.parse("g1 x10 y20");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_EQUAL(CommandType::G1, cmd.type);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 10.0f, cmd.x);
+}
+
+void test_g1_leading_whitespace() {
+    Command cmd = parser.parse("   G1 X5");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_EQUAL(CommandType::G1, cmd.type);
+}
+
+void test_g1_default_feedrate() {
+    // Fresh parser: sticky feedrate defaults to 3000 mm/min
+    Command cmd = parser.parse("G1 X10");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 3000.0f, cmd.f);
+}
+
+void test_g1_sticky_feedrate() {
+    parser.parse("G1 X10 F1200");
+    Command cmd = parser.parse("G1 X20");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1200.0f, cmd.f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1200.0f, parser.getFeedrate());
+}
+
+void test_g1_omitted_axes_are_nan() {
+    Command cmd = parser.parse("G1 X10");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_TRUE(isnan(cmd.y));
+}
+
+// ------------------------------------------------------------ G1 validation
+
+void test_g1_x_bound_max_ok() {
+    Command cmd = parser.parse("G1 X355 Y0");
+    TEST_ASSERT_TRUE(cmd.valid);
+}
+
+void test_g1_x_out_of_bounds() {
+    Command cmd = parser.parse("G1 X355.1");
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_OUT_OF_BOUNDS, cmd.errorCode);
+}
+
+void test_g1_y_bound_max_ok() {
+    Command cmd = parser.parse("G1 Y160");
+    TEST_ASSERT_TRUE(cmd.valid);
+}
+
+void test_g1_y_out_of_bounds() {
+    Command cmd = parser.parse("G1 Y160.1");
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_OUT_OF_BOUNDS, cmd.errorCode);
+}
+
+void test_g1_negative_x_rejected() {
+    Command cmd = parser.parse("G1 X-0.5");
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_OUT_OF_BOUNDS, cmd.errorCode);
+}
+
+// -------------------------------------------------------------- G28 homing
+
+void test_g28_no_params_homes_both() {
+    Command cmd = parser.parse("G28");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_EQUAL(CommandType::G28, cmd.type);
+    TEST_ASSERT_TRUE(cmd.homeX);
+    TEST_ASSERT_TRUE(cmd.homeY);
+}
+
+void test_g28_x_only() {
+    Command cmd = parser.parse("G28 X");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_TRUE(cmd.homeX);
+    TEST_ASSERT_FALSE(cmd.homeY);
+}
+
+void test_g28_y_only() {
+    Command cmd = parser.parse("G28 Y");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_FALSE(cmd.homeX);
+    TEST_ASSERT_TRUE(cmd.homeY);
+}
+
+void test_g28_both_axes() {
+    Command cmd = parser.parse("G28 X Y");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_TRUE(cmd.homeX);
+    TEST_ASSERT_TRUE(cmd.homeY);
+}
+
+void test_g28_unknown_axis_falls_back_to_both() {
+    // Coded behavior: unrecognized axis letters -> home both
+    Command cmd = parser.parse("G28 Z");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_TRUE(cmd.homeX);
+    TEST_ASSERT_TRUE(cmd.homeY);
+}
+
+// ------------------------------------------------------- G90/G91 mode flags
+
+void test_g90_sets_absolute_mode() {
+    parser.parse("G91");
+    TEST_ASSERT_FALSE(parser.isAbsoluteMode());
+    Command cmd = parser.parse("G90");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_EQUAL(CommandType::G90, cmd.type);
+    TEST_ASSERT_TRUE(parser.isAbsoluteMode());
+}
+
+void test_g91_sets_relative_mode() {
+    Command cmd = parser.parse("G91");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_EQUAL(CommandType::G91, cmd.type);
+    TEST_ASSERT_FALSE(parser.isAbsoluteMode());
+}
+
+// ------------------------------------------------------------- M code table
+
+void test_m_code_dispatch() {
+    struct { const char* line; CommandType expected; } cases[] = {
+        {"M3", CommandType::M3},
+        {"M5", CommandType::M5},
+        {"M17", CommandType::M17},
+        {"M18", CommandType::M18},
+        {"M112", CommandType::M112},
+        {"M114", CommandType::M114},
+        {"M119", CommandType::M119},
+        {"M400", CommandType::M400},
+        {"M999", CommandType::M999},
+    };
+    for (auto& c : cases) {
+        Command cmd = parser.parse(c.line);
+        TEST_ASSERT_TRUE_MESSAGE(cmd.valid, c.line);
+        TEST_ASSERT_EQUAL_MESSAGE(c.expected, cmd.type, c.line);
+    }
+}
+
+// ---------------------------------------------------------------- rejection
+
+void test_unknown_g_code() {
+    Command cmd = parser.parse("G999");
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_UNKNOWN_CMD, cmd.errorCode);
+}
+
+void test_unknown_m_code() {
+    Command cmd = parser.parse("M42");
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_UNKNOWN_CMD, cmd.errorCode);
+}
+
+void test_non_gm_line_rejected() {
+    Command cmd = parser.parse("X10 Y20");
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_UNKNOWN_CMD, cmd.errorCode);
+}
+
+void test_bare_g_rejected() {
+    Command cmd = parser.parse("G");
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_UNKNOWN_CMD, cmd.errorCode);
+}
+
+void test_null_line_invalid_param() {
+    Command cmd = parser.parse(nullptr);
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_INVALID_PARAM, cmd.errorCode);
+}
+
+void test_empty_line_invalid_param() {
+    Command cmd = parser.parse("");
+    TEST_ASSERT_FALSE(cmd.valid);
+    TEST_ASSERT_EQUAL_UINT8(ERR_INVALID_PARAM, cmd.errorCode);
+}
+
+void test_comment_line_is_noop() {
+    Command cmd = parser.parse("; just a comment");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_EQUAL(CommandType::NONE, cmd.type);
+}
+
+void test_paren_comment_is_noop() {
+    Command cmd = parser.parse("(comment)");
+    TEST_ASSERT_TRUE(cmd.valid);
+    TEST_ASSERT_EQUAL(CommandType::NONE, cmd.type);
+}
+
+// ------------------------------------------------------- feedrate mutators
+
+void test_set_feedrate_bounds() {
+    parser.setFeedrate(1500.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1500.0f, parser.getFeedrate());
+    parser.setFeedrate(5000.0f);  // > 3000: rejected
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1500.0f, parser.getFeedrate());
+    parser.setFeedrate(-1.0f);  // <= 0: rejected
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1500.0f, parser.getFeedrate());
+}
+
+// -------------------------------------------------------- response formats
+
+void test_format_position_response() {
+    char buf[64];
+    ProtocolParser::formatPositionResponse(12.5f, 34.0f, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("ok X:12.50 Y:34.00", buf);
+}
+
+void test_format_endstop_response() {
+    char buf[64];
+    ProtocolParser::formatEndstopResponse(true, false, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("ok ENDSTOPS X:1 Y:0", buf);
+}
+
+void test_format_error_responses() {
+    // Regression net for the SM-DES-003 code table, including the
+    // historically-swapped codes 5 (ESTOP) and 6 (BUSY)
+    char buf[64];
+    ProtocolParser::formatErrorResponse(ERR_UNKNOWN_CMD, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("error:1 Unknown command", buf);
+    ProtocolParser::formatErrorResponse(ERR_OUT_OF_BOUNDS, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("error:3 Move out of bounds", buf);
+    ProtocolParser::formatErrorResponse(ERR_ESTOP_ACTIVE, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("error:5 Emergency stop active", buf);
+    ProtocolParser::formatErrorResponse(ERR_BUSY, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("error:6 Busy", buf);
+}
+
+// -------------------------------------------------------------------- main
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_g1_full_parameters);
+    RUN_TEST(test_g1_compact_no_spaces);
+    RUN_TEST(test_g1_lowercase);
+    RUN_TEST(test_g1_leading_whitespace);
+    RUN_TEST(test_g1_default_feedrate);
+    RUN_TEST(test_g1_sticky_feedrate);
+    RUN_TEST(test_g1_omitted_axes_are_nan);
+    RUN_TEST(test_g1_x_bound_max_ok);
+    RUN_TEST(test_g1_x_out_of_bounds);
+    RUN_TEST(test_g1_y_bound_max_ok);
+    RUN_TEST(test_g1_y_out_of_bounds);
+    RUN_TEST(test_g1_negative_x_rejected);
+    RUN_TEST(test_g28_no_params_homes_both);
+    RUN_TEST(test_g28_x_only);
+    RUN_TEST(test_g28_y_only);
+    RUN_TEST(test_g28_both_axes);
+    RUN_TEST(test_g28_unknown_axis_falls_back_to_both);
+    RUN_TEST(test_g90_sets_absolute_mode);
+    RUN_TEST(test_g91_sets_relative_mode);
+    RUN_TEST(test_m_code_dispatch);
+    RUN_TEST(test_unknown_g_code);
+    RUN_TEST(test_unknown_m_code);
+    RUN_TEST(test_non_gm_line_rejected);
+    RUN_TEST(test_bare_g_rejected);
+    RUN_TEST(test_null_line_invalid_param);
+    RUN_TEST(test_empty_line_invalid_param);
+    RUN_TEST(test_comment_line_is_noop);
+    RUN_TEST(test_paren_comment_is_noop);
+    RUN_TEST(test_set_feedrate_bounds);
+    RUN_TEST(test_format_position_response);
+    RUN_TEST(test_format_endstop_response);
+    RUN_TEST(test_format_error_responses);
+    return UNITY_END();
+}

--- a/firmware/esp32/test/test_scurve/test_scurve.cpp
+++ b/firmware/esp32/test/test_scurve/test_scurve.cpp
@@ -1,0 +1,210 @@
+/**
+ * @file test_scurve.cpp
+ * @brief Native unit tests for SCurveGenerator (SM-DES-007 §4, todolist S5-21).
+ *
+ * Expected values are derived from config.h constants so the tests track
+ * configuration changes:
+ *   V_MAX_MM_S = 50, A_MAX_MM_S2 = 500, J_MAX_MM_S3 = 2000
+ *   tJ = min(A/J, sqrt(v/J));  dJerk = J * tJ^3 / 6
+ *
+ * Run with: pio test -e native
+ */
+
+#include <unity.h>
+#include <math.h>
+#include "scurve.h"
+
+static SCurveGenerator gen;
+
+// Jerk time as coded: min(A/J, sqrt(v/J))
+static float jerkTime(float v) {
+    float t1 = A_MAX_MM_S2 / J_MAX_MM_S3;
+    float t2 = sqrtf(v / J_MAX_MM_S3);
+    return (t1 < t2) ? t1 : t2;
+}
+
+// Jerk-phase distance as coded: J * tJ^3 / 6
+static float jerkDistance(float tJ) {
+    return J_MAX_MM_S3 * tJ * tJ * tJ / 6.0f;
+}
+
+void setUp() {}
+void tearDown() {}
+
+// ------------------------------------------------------------ long moves
+
+void test_long_move_profile_shape() {
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    float tJ = jerkTime(V_MAX_MM_S);
+    float dJ = jerkDistance(tJ);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 100.0f, p.distance);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, V_MAX_MM_S, p.vCruise);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, tJ, p.tJ);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, tJ, p.tAccel);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, tJ, p.tDecel);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, dJ, p.dAccel);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, dJ, p.dDecel);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 100.0f - 2.0f * dJ, p.dCruise);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, p.dCruise / p.vCruise, p.tCruise);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, p.tAccel + p.tCruise + p.tDecel, p.tTotal);
+}
+
+void test_long_move_phase_distances_sum_to_total() {
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, p.distance, p.dAccel + p.dCruise + p.dDecel);
+}
+
+void test_velocity_target_clamped_to_vmax() {
+    SCurveProfile p = gen.plan(100.0f, 999.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, V_MAX_MM_S, p.vCruise);
+}
+
+void test_nonpositive_velocity_defaults_to_vmax() {
+    SCurveProfile p1 = gen.plan(100.0f, 0.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, V_MAX_MM_S, p1.vCruise);
+    SCurveProfile p2 = gen.plan(100.0f, -3.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, V_MAX_MM_S, p2.vCruise);
+}
+
+void test_negative_distance_uses_magnitude() {
+    SCurveProfile p = gen.plan(-40.0f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 40.0f, p.distance);
+}
+
+// ----------------------------------------------------------- short moves
+
+void test_short_move_reduces_peak_velocity() {
+    // 0.5 mm < d_min: v_peak = sqrt(J * d), no cruise phase
+    SCurveProfile p = gen.plan(0.5f, V_MAX_MM_S);
+    float vPeak = sqrtf(J_MAX_MM_S3 * 0.5f);
+    float tJ = jerkTime(vPeak);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, vPeak, p.vCruise);
+    TEST_ASSERT_TRUE(p.vCruise < V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, p.tCruise);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, p.dCruise);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, tJ, p.tJ);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, p.dAccel, p.dDecel);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f * tJ, p.tTotal);
+}
+
+void test_short_move_distance_consistency_KNOWN_ISSUE() {
+    // KNOWN ISSUE (found while writing these tests, 2026-07-09):
+    // for short moves the coded v_peak = sqrt(J*d) does not satisfy the
+    // profile's own kinematics: dAccel + dDecel = 2*(J*tJ^3/6) != d.
+    // For d = 0.5 mm the phase distances sum to ~1.33 mm, so getPosition()
+    // overshoots d during the accel phase and snaps back to d at tTotal.
+    // Fix belongs in a reviewed firmware change before H3 bench bring-up.
+    TEST_IGNORE_MESSAGE("scurve.cpp short-move math inconsistent: sum(phase distances) != distance");
+}
+
+void test_near_dmin_move_cruise_nonnegative_KNOWN_ISSUE() {
+    // KNOWN ISSUE (same root cause): the d_min = v^2/J = 1.25 mm threshold
+    // does not match the coded jerk-phase distance 2*dJerk ~= 2.64 mm.
+    // Moves in (1.25, 2.64) mm take the full-curve branch and get a
+    // NEGATIVE dCruise/tCruise. Example: plan(2.0, 50) -> tCruise < 0.
+    // No production move today falls in this window (homing backoff is
+    // 5 mm; bin pitch >= 50 mm), but it must be fixed before H3.
+    TEST_IGNORE_MESSAGE("scurve.cpp d_min threshold inconsistent with 2*dJerk; negative cruise in (1.25, 2.64) mm");
+}
+
+// ------------------------------------------------------- velocity queries
+
+void test_velocity_zero_outside_profile() {
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, gen.getVelocity(p, -1.0f));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, gen.getVelocity(p, p.tTotal + 1.0f));
+}
+
+void test_velocity_during_jerk_rampup() {
+    // v(t) = J * t^2 / 2 during accel
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, J_MAX_MM_S3 * 0.1f * 0.1f / 2.0f,
+                             gen.getVelocity(p, 0.1f));
+}
+
+void test_velocity_monotonic_during_accel() {
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    float v1 = gen.getVelocity(p, 0.05f);
+    float v2 = gen.getVelocity(p, 0.10f);
+    float v3 = gen.getVelocity(p, 0.15f);
+    TEST_ASSERT_TRUE(v1 < v2);
+    TEST_ASSERT_TRUE(v2 < v3);
+}
+
+void test_velocity_equals_cruise_in_cruise_phase() {
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    float tMid = p.tAccel + p.tCruise / 2.0f;
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, p.vCruise, gen.getVelocity(p, tMid));
+}
+
+// ------------------------------------------------------- position queries
+
+void test_position_boundaries() {
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, gen.getPosition(p, -1.0f));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, gen.getPosition(p, 0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 100.0f, gen.getPosition(p, p.tTotal));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 100.0f, gen.getPosition(p, p.tTotal + 5.0f));
+}
+
+void test_position_during_jerk_rampup() {
+    // d(t) = J * t^3 / 6 during accel
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, J_MAX_MM_S3 * 0.001f / 6.0f,
+                             gen.getPosition(p, 0.1f));
+}
+
+void test_position_in_cruise_phase() {
+    // pos = dAccel + vCruise * (t - tAccel)
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    float t = p.tAccel + 1.0f;
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, p.dAccel + p.vCruise * 1.0f,
+                             gen.getPosition(p, t));
+}
+
+void test_position_monotonic_in_long_move() {
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    float p1 = gen.getPosition(p, 0.5f);
+    float p2 = gen.getPosition(p, 1.0f);
+    float p3 = gen.getPosition(p, 2.0f);
+    TEST_ASSERT_TRUE(p1 < p2);
+    TEST_ASSERT_TRUE(p2 < p3);
+}
+
+// ----------------------------------------------------------- phase queries
+
+void test_phase_sequence() {
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    TEST_ASSERT_EQUAL(SCurvePhase::IDLE, gen.getPhase(p, -0.1f));
+    TEST_ASSERT_EQUAL(SCurvePhase::ACCELERATING, gen.getPhase(p, p.tAccel / 2.0f));
+    TEST_ASSERT_EQUAL(SCurvePhase::CRUISING, gen.getPhase(p, p.tAccel + p.tCruise / 2.0f));
+    TEST_ASSERT_EQUAL(SCurvePhase::DECELERATING,
+                      gen.getPhase(p, p.tAccel + p.tCruise + p.tDecel / 2.0f));
+    TEST_ASSERT_EQUAL(SCurvePhase::COMPLETE, gen.getPhase(p, p.tTotal + 0.1f));
+}
+
+// -------------------------------------------------------------------- main
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_long_move_profile_shape);
+    RUN_TEST(test_long_move_phase_distances_sum_to_total);
+    RUN_TEST(test_velocity_target_clamped_to_vmax);
+    RUN_TEST(test_nonpositive_velocity_defaults_to_vmax);
+    RUN_TEST(test_negative_distance_uses_magnitude);
+    RUN_TEST(test_short_move_reduces_peak_velocity);
+    RUN_TEST(test_short_move_distance_consistency_KNOWN_ISSUE);
+    RUN_TEST(test_near_dmin_move_cruise_nonnegative_KNOWN_ISSUE);
+    RUN_TEST(test_velocity_zero_outside_profile);
+    RUN_TEST(test_velocity_during_jerk_rampup);
+    RUN_TEST(test_velocity_monotonic_during_accel);
+    RUN_TEST(test_velocity_equals_cruise_in_cruise_phase);
+    RUN_TEST(test_position_boundaries);
+    RUN_TEST(test_position_during_jerk_rampup);
+    RUN_TEST(test_position_in_cruise_phase);
+    RUN_TEST(test_position_monotonic_in_long_move);
+    RUN_TEST(test_phase_sequence);
+    return UNITY_END();
+}

--- a/modules/training/preprocessing.py
+++ b/modules/training/preprocessing.py
@@ -12,7 +12,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def find_turntable_circle(image: np.ndarray) -> tuple:
+def find_turntable_circle(image: np.ndarray) -> tuple | None:
     """Detect the gray circular turntable in the image.
 
     Returns:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pandas>=2.0.0
 PyYAML>=6.0
 pydantic>=2.0.0
+requests>=2.31.0  # APIClient -> PC inference server (SM-SPEC-001 §3.1)
 
 # Vision - use headless for Raspberry Pi (no GUI dependencies)
 opencv-python-headless>=4.5.0


### PR DESCRIPTION
Closes the last non-hardware software gap: 67 native Unity test cases for the three pure-logic firmware modules, run via `pio test -e native` in a new CI job (no ESP32 hardware needed).

- **test_protocol** (32): G/M dispatch, G1 bounds + sticky feedrate, G28 flags, G90/G91, rejection paths, SM-DES-003 response formats incl. the error 5/6 regression net
- **test_scurve** (17): profile shape from config.h constants, clamping, short-move branch, velocity/position/phase queries. **2 IGNORED cases document real math inconsistencies found while writing these tests** (short-move phase-distance sum ≠ distance; d_min=1.25mm threshold vs actual 2·dJerk≈2.64mm ⇒ negative cruise in that window). Fix deferred to a reviewed firmware change before H3.
- **test_motion** (18): Bresenham major-axis/ratio/step counts, bounds, feedrate clamp, execute dispatch through a StepperDriver fake
- `[env:native]` enabled; `default_envs = esp32dev` keeps `pio run` device-only (esp32dev compile re-verified locally, SUCCESS 19.7s)
- CI: new `firmware-native-tests` job (ubuntu GCC toolchain — no local MinGW available, per plan)