### PR TITLE
fix(firmware): make S-curve math self-consistent, un-ignore scurve tests

### DIFF
--- a/firmware/esp32/include/scurve.h
+++ b/firmware/esp32/include/scurve.h
@@ -6,12 +6,13 @@
  * 
  * Profile: P1 (jerk ramp-up) → P4 (cruise) → P7 (jerk ramp-down)
  * 
- * Key formulas:
- *   t_j = min(a_max / j_max, sqrt(v_target / j_max))
- *   d_min = v_max² / j_max = 1.25 mm
- * 
- * @version 1.0
- * @date 2026-03-10
+ * Key formulas (single constant-jerk ramp per side):
+ *   t_j   = sqrt(2 × v_target / j_max), capped at a_max / j_max
+ *   d_min = v × t_j ≈ 11.18 mm at v_max = 50 mm/s
+ *   short moves (d < d_min): v_peak = cbrt(j_max × d² / 2)
+ *
+ * @version 1.1
+ * @date 2026-07-10
  */
 
 #ifndef SCURVE_H

--- a/firmware/esp32/src/scurve.cpp
+++ b/firmware/esp32/src/scurve.cpp
@@ -1,13 +1,20 @@
 /**
  * @file scurve.cpp
  * @brief S-Curve Motion Profile Implementation
- * 
+ *
  * Implements 3-segment S-curve profile per SM-DES-007 §4.3.
- * 
+ *
  * MVP S-curve: P1 (jerk ramp-up) → P4 (cruise) → P7 (jerk ramp-down)
- * 
- * For short moves (< d_min), reduces peak velocity:
- *   v_peak = sqrt(j_max × d)
+ *
+ * Each ramp is a single constant-jerk segment (no constant-accel phase):
+ *   ramp-up:   v(t) = j × t² / 2, reaches v_cruise at t_j = sqrt(2v / j)
+ *   distances: d_accel = v × t_j / 3,  d_decel = 2 × v × t_j / 3
+ *              (a single-jerk ramp is not distance-symmetric)
+ *   d_min     = d_accel + d_decel = v × t_j
+ *
+ * For short moves (< d_min), reduces peak velocity so the phase
+ * distances sum exactly to d:
+ *   v_peak = cbrt(j_max × d² / 2)
  */
 
 #include "scurve.h"
@@ -17,14 +24,18 @@ SCurveGenerator::SCurveGenerator() {
 }
 
 float SCurveGenerator::calculateMinDistance(float vMax) const {
-    // d_min = v_max² / j_max
-    return (vMax * vMax) / J_MAX_MM_S3;
+    // Shortest move that still reaches vMax: both ramps, no cruise.
+    // d_min = d_accel + d_decel = v × t_j
+    return vMax * calculateJerkTime(vMax);
 }
 
 float SCurveGenerator::calculateJerkTime(float vTarget) const {
-    // t_j = min(a_max / j_max, sqrt(v_target / j_max))
+    // Single constant-jerk ramp reaches v = j × t_j² / 2 at
+    // t_j = sqrt(2 × v_target / j_max)  (SM-DES-007 §4.5).
+    // The a_max/j_max cap cannot bind while v ≤ a_max²/(2·j_max) = 62.5 mm/s,
+    // which plan()'s V_MAX clamp guarantees.
     float t1 = A_MAX_MM_S2 / J_MAX_MM_S3;
-    float t2 = sqrtf(vTarget / J_MAX_MM_S3);
+    float t2 = sqrtf(2.0f * vTarget / J_MAX_MM_S3);
     return (t1 < t2) ? t1 : t2;
 }
 
@@ -34,7 +45,7 @@ SCurveProfile SCurveGenerator::plan(float distance, float vTarget) {
     profile.vStart = 0.0f;
     profile.vEnd = 0.0f;
     profile.phase = SCurvePhase::IDLE;
-    
+
     // Clamp target velocity
     if (vTarget > V_MAX_MM_S) {
         vTarget = V_MAX_MM_S;
@@ -42,46 +53,38 @@ SCurveProfile SCurveGenerator::plan(float distance, float vTarget) {
     if (vTarget <= 0) {
         vTarget = V_MAX_MM_S;
     }
-    
+
     // Calculate minimum distance for full S-curve
     float dMin = calculateMinDistance(vTarget);
-    
-    // Calculate jerk phase time
-    float tJ = calculateJerkTime(vTarget);
-    
-    // Calculate distance during jerk phase (ramp up to peak velocity)
-    // During jerk phase: a(t) = j × t, v(t) = j × t² / 2
-    // d_jerk = j × t_j³ / 6
-    float dJerk = J_MAX_MM_S3 * tJ * tJ * tJ / 6.0f;
-    
-    // Total acceleration distance (two jerk phases: accel + decel)
-    float dAccelDecel = 2.0f * dJerk;
-    
+
     if (profile.distance < dMin) {
-        // Short move: reduce peak velocity
-        // v_peak = sqrt(j_max × d)
-        profile.vCruise = sqrtf(J_MAX_MM_S3 * profile.distance);
-        profile.tJ = calculateJerkTime(profile.vCruise);
-        profile.tAccel = profile.tJ;
-        profile.tDecel = profile.tJ;
-        profile.tCruise = 0.0f;
-        profile.dAccel = J_MAX_MM_S3 * profile.tJ * profile.tJ * profile.tJ / 6.0f;
-        profile.dDecel = profile.dAccel;
-        profile.dCruise = 0.0f;
+        // Short move: no cruise. Solve d = v_peak × t_j(v_peak)
+        // = sqrt(2 × v_peak³ / j_max)  =>  v_peak = cbrt(j_max × d² / 2)
+        profile.vCruise = cbrtf(
+            J_MAX_MM_S3 * profile.distance * profile.distance / 2.0f);
     } else {
         // Full S-curve with cruise phase
         profile.vCruise = vTarget;
-        profile.tJ = tJ;
-        profile.tAccel = tJ;
-        profile.tDecel = tJ;
-        profile.dAccel = dJerk;
-        profile.dDecel = dJerk;
-        profile.dCruise = profile.distance - dAccelDecel;
-        profile.tCruise = profile.dCruise / profile.vCruise;
     }
-    
+
+    profile.tJ = calculateJerkTime(profile.vCruise);
+    profile.tAccel = profile.tJ;
+    profile.tDecel = profile.tJ;
+
+    // Ramp-up covers j × t_j³ / 6 = v × t_j / 3; ramp-down covers the
+    // mirror integral v × t_j − j × t_j³ / 6 = 2 × v × t_j / 3.
+    profile.dAccel = J_MAX_MM_S3 * profile.tJ * profile.tJ * profile.tJ / 6.0f;
+    profile.dDecel = 2.0f * profile.dAccel;
+
+    profile.dCruise = profile.distance - profile.dAccel - profile.dDecel;
+    if (profile.dCruise < 0.0f) {
+        profile.dCruise = 0.0f;  // float round-off on short moves
+    }
+    profile.tCruise =
+        (profile.vCruise > 0.0f) ? profile.dCruise / profile.vCruise : 0.0f;
+
     profile.tTotal = profile.tAccel + profile.tCruise + profile.tDecel;
-    
+
     return profile;
 }
 
@@ -99,11 +102,11 @@ float SCurveGenerator::getVelocity(const SCurveProfile& profile, float t) {
     if (t < 0 || t >= profile.tTotal) {
         return 0.0f;
     }
-    
+
     if (t < profile.tAccel) {
         // Acceleration phase (jerk ramp-up)
         return jerkVelocity(t, J_MAX_MM_S3, profile.tJ);
-    } 
+    }
     else if (t < profile.tAccel + profile.tCruise) {
         // Cruise phase
         return profile.vCruise;
@@ -111,7 +114,6 @@ float SCurveGenerator::getVelocity(const SCurveProfile& profile, float t) {
     else {
         // Deceleration phase (jerk ramp-down)
         float tDecel = t - profile.tAccel - profile.tCruise;
-        float tRemaining = profile.tDecel - tDecel;
         // Velocity decreases: v = v_cruise - jerk_velocity(tDecel)
         return profile.vCruise - jerkVelocity(tDecel, J_MAX_MM_S3, profile.tJ);
     }
@@ -124,30 +126,31 @@ float SCurveGenerator::getPosition(const SCurveProfile& profile, float t) {
     if (t >= profile.tTotal) {
         return profile.distance;
     }
-    
+
     float pos = 0.0f;
-    
+
     if (t < profile.tAccel) {
         // Acceleration phase
         return jerkPosition(t, J_MAX_MM_S3, profile.tJ);
     }
-    
+
     // Add full acceleration distance
     pos += profile.dAccel;
-    
+
     if (t < profile.tAccel + profile.tCruise) {
         // Cruise phase
         float tCruise = t - profile.tAccel;
         return pos + profile.vCruise * tCruise;
     }
-    
+
     // Add full cruise distance
     pos += profile.dCruise;
-    
-    // Deceleration phase
+
+    // Deceleration phase: v(τ) = v_cruise − j × τ² / 2, so
+    // d(τ) = v_cruise × τ − j × τ³ / 6
     float tDecel = t - profile.tAccel - profile.tCruise;
-    pos += jerkPosition(tDecel, J_MAX_MM_S3, profile.tJ);
-    
+    pos += profile.vCruise * tDecel - jerkPosition(tDecel, J_MAX_MM_S3, profile.tJ);
+
     return pos;
 }
 
@@ -158,7 +161,7 @@ SCurvePhase SCurveGenerator::getPhase(const SCurveProfile& profile, float t) {
     if (t >= profile.tTotal) {
         return SCurvePhase::COMPLETE;
     }
-    
+
     if (t < profile.tAccel) {
         return SCurvePhase::ACCELERATING;
     }

--- a/firmware/esp32/test/test_scurve/test_scurve.cpp
+++ b/firmware/esp32/test/test_scurve/test_scurve.cpp
@@ -5,7 +5,10 @@
  * Expected values are derived from config.h constants so the tests track
  * configuration changes:
  *   V_MAX_MM_S = 50, A_MAX_MM_S2 = 500, J_MAX_MM_S3 = 2000
- *   tJ = min(A/J, sqrt(v/J));  dJerk = J * tJ^3 / 6
+ *   tJ = sqrt(2v/J) (single constant-jerk ramp reaching v; A/J cap
+ *   cannot bind for v <= A^2/(2J) = 62.5 mm/s)
+ *   dAccel = J * tJ^3 / 6 = v*tJ/3;  dDecel = 2*dAccel;  dMin = v*tJ
+ *   short moves (d < dMin): vPeak = cbrt(J * d^2 / 2)
  *
  * Run with: pio test -e native
  */
@@ -16,14 +19,14 @@
 
 static SCurveGenerator gen;
 
-// Jerk time as coded: min(A/J, sqrt(v/J))
+// Ramp time: single constant-jerk ramp reaches v = J*tJ^2/2
 static float jerkTime(float v) {
     float t1 = A_MAX_MM_S2 / J_MAX_MM_S3;
-    float t2 = sqrtf(v / J_MAX_MM_S3);
+    float t2 = sqrtf(2.0f * v / J_MAX_MM_S3);
     return (t1 < t2) ? t1 : t2;
 }
 
-// Jerk-phase distance as coded: J * tJ^3 / 6
+// Ramp-up distance: J * tJ^3 / 6 (= v*tJ/3); ramp-down covers twice this
 static float jerkDistance(float tJ) {
     return J_MAX_MM_S3 * tJ * tJ * tJ / 6.0f;
 }
@@ -44,8 +47,8 @@ void test_long_move_profile_shape() {
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, tJ, p.tAccel);
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, tJ, p.tDecel);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, dJ, p.dAccel);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, dJ, p.dDecel);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 100.0f - 2.0f * dJ, p.dCruise);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f * dJ, p.dDecel);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 100.0f - 3.0f * dJ, p.dCruise);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, p.dCruise / p.vCruise, p.tCruise);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, p.tAccel + p.tCruise + p.tDecel, p.tTotal);
 }
@@ -75,9 +78,9 @@ void test_negative_distance_uses_magnitude() {
 // ----------------------------------------------------------- short moves
 
 void test_short_move_reduces_peak_velocity() {
-    // 0.5 mm < d_min: v_peak = sqrt(J * d), no cruise phase
+    // 0.5 mm < d_min: v_peak = cbrt(J * d^2 / 2), no cruise phase
     SCurveProfile p = gen.plan(0.5f, V_MAX_MM_S);
-    float vPeak = sqrtf(J_MAX_MM_S3 * 0.5f);
+    float vPeak = cbrtf(J_MAX_MM_S3 * 0.5f * 0.5f / 2.0f);
     float tJ = jerkTime(vPeak);
 
     TEST_ASSERT_FLOAT_WITHIN(0.001f, vPeak, p.vCruise);
@@ -85,28 +88,55 @@ void test_short_move_reduces_peak_velocity() {
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, p.tCruise);
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, p.dCruise);
     TEST_ASSERT_FLOAT_WITHIN(0.0001f, tJ, p.tJ);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, p.dAccel, p.dDecel);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f * p.dAccel, p.dDecel);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f * tJ, p.tTotal);
 }
 
-void test_short_move_distance_consistency_KNOWN_ISSUE() {
-    // KNOWN ISSUE (found while writing these tests, 2026-07-09):
-    // for short moves the coded v_peak = sqrt(J*d) does not satisfy the
-    // profile's own kinematics: dAccel + dDecel = 2*(J*tJ^3/6) != d.
-    // For d = 0.5 mm the phase distances sum to ~1.33 mm, so getPosition()
-    // overshoots d during the accel phase and snaps back to d at tTotal.
-    // Fix belongs in a reviewed firmware change before H3 bench bring-up.
-    TEST_IGNORE_MESSAGE("scurve.cpp short-move math inconsistent: sum(phase distances) != distance");
+void test_short_move_phase_distances_sum_to_total() {
+    // Was TEST_IGNORE (KNOWN ISSUE, 2026-07-09): v_peak = sqrt(J*d) left the
+    // phase distances summing to ~1.33 mm for a 0.5 mm move. Fixed 2026-07-10:
+    // v_peak = cbrt(J*d^2/2) makes d_accel + d_decel = d exactly.
+    SCurveProfile p = gen.plan(0.5f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, p.dAccel + p.dCruise + p.dDecel);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, gen.getPosition(p, p.tTotal));
 }
 
-void test_near_dmin_move_cruise_nonnegative_KNOWN_ISSUE() {
-    // KNOWN ISSUE (same root cause): the d_min = v^2/J = 1.25 mm threshold
-    // does not match the coded jerk-phase distance 2*dJerk ~= 2.64 mm.
-    // Moves in (1.25, 2.64) mm take the full-curve branch and get a
-    // NEGATIVE dCruise/tCruise. Example: plan(2.0, 50) -> tCruise < 0.
-    // No production move today falls in this window (homing backoff is
-    // 5 mm; bin pitch >= 50 mm), but it must be fixed before H3.
-    TEST_IGNORE_MESSAGE("scurve.cpp d_min threshold inconsistent with 2*dJerk; negative cruise in (1.25, 2.64) mm");
+void test_cruise_nonnegative_across_distance_sweep() {
+    // Was TEST_IGNORE (KNOWN ISSUE, 2026-07-09): d_min = v^2/J = 1.25 mm
+    // undercut the real ramp distance, so moves in (1.25, 2.64) mm got a
+    // NEGATIVE dCruise/tCruise. Fixed 2026-07-10: d_min = v*tJ is the same
+    // expression the full branch subtracts, so cruise >= 0 by construction.
+    // Sweep covers the old dead zone and both branch sides of the new d_min.
+    const float distances[] = {0.3f, 0.5f, 1.25f, 2.0f, 2.64f,
+                               5.0f, 11.0f, 11.2f, 20.0f, 100.0f};
+    for (unsigned i = 0; i < sizeof(distances) / sizeof(distances[0]); i++) {
+        SCurveProfile p = gen.plan(distances[i], V_MAX_MM_S);
+        TEST_ASSERT_TRUE(p.tCruise >= 0.0f);
+        TEST_ASSERT_TRUE(p.dCruise >= 0.0f);
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, distances[i],
+                                 p.dAccel + p.dCruise + p.dDecel);
+    }
+}
+
+// -------------------------------------------------------- ramp kinematics
+
+void test_ramp_reaches_cruise_velocity() {
+    // Velocity continuity at cruise entry: the ramp must END at vCruise
+    // (J*tJ^2/2 == vCruise). The pre-fix tJ = sqrt(v/J) ended the ramp at
+    // vCruise/2 — a commanded 25 mm/s velocity step at v = 50. Stall risk.
+    SCurveProfile pLong = gen.plan(100.0f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, pLong.vCruise,
+                             J_MAX_MM_S3 * pLong.tJ * pLong.tJ / 2.0f);
+    SCurveProfile pShort = gen.plan(0.5f, V_MAX_MM_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, pShort.vCruise,
+                             J_MAX_MM_S3 * pShort.tJ * pShort.tJ / 2.0f);
+}
+
+void test_peak_acceleration_within_amax() {
+    // Peak accel during the ramp is J*tJ; must respect A_MAX
+    // (at v_max = 50: sqrt(2*50*2000) ~= 447 mm/s^2 < 500)
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    TEST_ASSERT_TRUE(J_MAX_MM_S3 * p.tJ <= A_MAX_MM_S2 + 0.01f);
 }
 
 // ------------------------------------------------------- velocity queries
@@ -164,6 +194,17 @@ void test_position_in_cruise_phase() {
                              gen.getPosition(p, t));
 }
 
+void test_position_during_decel_ramp() {
+    // pos = dAccel + dCruise + vCruise*tau - J*tau^3/6 (integral of the
+    // decel velocity v_cruise - J*tau^2/2, NOT the accel integral)
+    SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
+    float tau = p.tDecel / 2.0f;
+    float expected = p.dAccel + p.dCruise + p.vCruise * tau -
+                     J_MAX_MM_S3 * tau * tau * tau / 6.0f;
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, expected,
+                             gen.getPosition(p, p.tAccel + p.tCruise + tau));
+}
+
 void test_position_monotonic_in_long_move() {
     SCurveProfile p = gen.plan(100.0f, V_MAX_MM_S);
     float p1 = gen.getPosition(p, 0.5f);
@@ -195,8 +236,10 @@ int main(int, char**) {
     RUN_TEST(test_nonpositive_velocity_defaults_to_vmax);
     RUN_TEST(test_negative_distance_uses_magnitude);
     RUN_TEST(test_short_move_reduces_peak_velocity);
-    RUN_TEST(test_short_move_distance_consistency_KNOWN_ISSUE);
-    RUN_TEST(test_near_dmin_move_cruise_nonnegative_KNOWN_ISSUE);
+    RUN_TEST(test_short_move_phase_distances_sum_to_total);
+    RUN_TEST(test_cruise_nonnegative_across_distance_sweep);
+    RUN_TEST(test_ramp_reaches_cruise_velocity);
+    RUN_TEST(test_peak_acceleration_within_amax);
     RUN_TEST(test_velocity_zero_outside_profile);
     RUN_TEST(test_velocity_during_jerk_rampup);
     RUN_TEST(test_velocity_monotonic_during_accel);
@@ -204,6 +247,7 @@ int main(int, char**) {
     RUN_TEST(test_position_boundaries);
     RUN_TEST(test_position_during_jerk_rampup);
     RUN_TEST(test_position_in_cruise_phase);
+    RUN_TEST(test_position_during_decel_ramp);
     RUN_TEST(test_position_monotonic_in_long_move);
     RUN_TEST(test_phase_sequence);
     return UNITY_END();


### PR DESCRIPTION
Fixes the two known scurve.cpp math bugs documented as TEST_IGNORE cases in #15.

## Root cause
The 3-segment profile mixed two ramp models: `calculateJerkTime()` used `tJ = sqrt(v/J)` (two-jerk-segment formula) while `getVelocity()`/`getPosition()` integrate a **single** constant-jerk ramp (`v = J*t^2/2`).

## Consequences (pre-fix)
- Ramp ended at `vCruise/2` -> commanded 25 mm/s velocity step at cruise entry (stall risk)
- Short-move `v_peak = sqrt(J*d)` -> phase distances summed to ~2.65x the move distance
- `d_min = v^2/J` (1.25 mm) undercut the real ramp distance -> **negative cruise time** for moves in the 1.25-2.64 mm window

## Fix
Everything derived from the single-ramp model (SM-DES-007 §4.5 already specified `tJ = sqrt(2v/J)` — the firmware contradicted its own design doc):

| Quantity | Old | New |
|---|---|---|
| tJ | sqrt(v/J) | sqrt(2v/J) |
| dAccel / dDecel | dJerk / dJerk | v·tJ/3 / 2·v·tJ/3 |
| d_min | v²/J = 1.25 mm | v·tJ = 11.18 mm |
| short-move v_peak | sqrt(J·d) | cbrt(J·d²/2) — phases sum to d **exactly** |
| decel position | accel integral (wrong) | v·τ − J·τ³/6 |

## Verification
- 60/60 numerical checks in a Python replica (incl. dense monotonicity + velocity continuity at all phase boundaries)
- `pio run` device build SUCCESS locally
- Both TEST_IGNORE cases are now active assertions; +3 new regression nets (ramp-reaches-cruise, peak-accel ≤ A_MAX, decel-position integral). 67 -> 70 native cases.
- SM-DES-007 bumped to v1.1 in the PM tree (formulas corrected to match).